### PR TITLE
Fix: Use Microsoft Playwright GitHub Action for CI browser installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
           NEXT_PUBLIC_BASE_URL: http://localhost:3009
 
-      - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+      - name: Install Playwright
+        uses: microsoft/playwright-github-action@v1
 
       - name: Run E2E tests
         run: bun test:e2e


### PR DESCRIPTION
E2E tests were failing in CI with Playwright browser installation errors. Replaced bunx playwright install with the official microsoft/playwright-github-action@v1. This ensures proper browser installation with all system dependencies.